### PR TITLE
Added comment about pre-included libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,23 +31,36 @@ Replace:
 or
 
 	#if defined(ARDUINO) && ARDUINO >= 100
-	#include "Arduino.h"	// for digitalRead, digitalWrite, etc
+	  #include "Arduino.h"	// for digitalRead, digitalWrite, etc
 	#else
-	#include "WProgram.h"
+	  #include "WProgram.h"
 	#endif
 
 with
 
 	#if defined (SPARK)
-	#include "application.h"
+	  #include "application.h"
 	#else
-	#if defined(ARDUINO) && ARDUINO >= 100
-	#include "Arduino.h"
-	#else
-	#include "WProgram.h"
-	#endif
+	  #if defined(ARDUINO) && ARDUINO >= 100
+	    #include "Arduino.h"
+	  #else
+	    #include "WProgram.h"
+	  #endif
+	  // here could follow some of the includes only needed on Arduino
+	  // see bellow
+	  
 	#endif
 
+Some libraries that need including on Arduino, are already "pre-included" via `application.h`
+
+So for example
+
+	EEPROM.h
+	SPI.h
+	WiFi.h
+	Wire.h
+	
+	
 ### Getting the User LED to work
 #### Common Problems
 ``The user LED doesn't light up!``

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ So for example
 	SPI.h
 	WiFi.h
 	Wire.h
+	...
 	
 	
 ### Getting the User LED to work


### PR DESCRIPTION
Due to some question in this thread
http://community.spark.io/t/adafruit-ads1015-adc-library-for-spark/9193
I thought it might be useful to add this info